### PR TITLE
Compatibility with adapter v0.7.0

### DIFF
--- a/adapter-git.gemspec
+++ b/adapter-git.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency 'adapter', '~> 0.5.1'
+  s.add_dependency 'adapter', '~> 0.7.0'
   s.add_dependency 'grit', '~> 2.0'
   s.add_development_dependency 'rspec', '~> 2.0'
   s.add_development_dependency 'rake'

--- a/lib/adapter/git.rb
+++ b/lib/adapter/git.rb
@@ -12,32 +12,32 @@ module Adapter
       client.get_head(branch)
     end
 
-    def key?(key)
+    def key?(key, options = nil)
       !(head && head.commit.tree / key_for(key)).nil?
     end
 
-    def read(key)
+    def read(key, options = nil)
       if head && blob = head.commit.tree / key_for(key)
         decode(blob.data)
       end
     end
 
-    def write(key, value)
+    def write(key, value, options = nil)
       commit("Updated #{key}") do |index|
         index.add(key_for(key), encode(value))
       end
     end
 
-    def delete(key)
+    def delete(key, options = nil)
       read(key).tap do
         commit("Delete #{key}") {|index| index.delete(key_for(key)) }
       end
     end
 
-    def clear
+    def clear(options = nil)
       commit("Cleared") do |index|
         tree = index.current_tree
-        tree = tree / options[:path] if options[:path] && tree
+        tree = tree / self.options[:path] if self.options[:path] && tree
         if tree
           tree.contents.each do |entry|
             index.delete(key_for(entry.name))
@@ -55,7 +55,7 @@ module Adapter
     end
 
     def key_for(key)
-      File.join(*[options[:path], super].compact)
+      File.join(*[options[:path], serialize_key(key)].compact)
     end
 
   private
@@ -71,6 +71,16 @@ module Adapter
       yield index
 
       index.commit(message, :parents => Array(commit), :head => branch) unless index.tree.empty?
+    end
+
+    def serialize_key(key)
+      if key.is_a?(String)
+        key
+      elsif key.is_a?(Symbol)
+        key.to_s
+      else
+        Marshal.dump(key)
+      end
     end
 
   end

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -12,14 +12,14 @@ describe "Git adapter" do
     # Some adapter specs don't pass if there is not at least one commit in the
     # repo since the git adapter short-circuits the key marshalling if there
     # are no commits.
-    adapter.set('specs', 'running')
+    adapter.write('specs', 'running')
   end
 
   it_should_behave_like 'an adapter'
 
   it 'should create a branch when it does not exist' do
     adapter.options[:branch] = 'foobar'
-    adapter.set('foo', 'bar')
+    adapter.write('foo', 'bar')
     client.get_head('foobar').should_not be_nil
   end
 
@@ -29,9 +29,9 @@ describe "Git adapter" do
   end
 
   it 'should successfully delete a key' do
-    adapter.set('foo', 'bar')
+    adapter.write('foo', 'bar')
     adapter.delete('foo')
-    adapter.get('foo').should be_nil
+    adapter.read('foo').should be_nil
   end
 
   it 'should not generate a commit message if there are no changes' do
@@ -49,20 +49,20 @@ describe "Git adapter" do
     it_should_behave_like 'an adapter'
 
     it 'should store keys in the directory' do
-      adapter.set('foo', 'bar')
+      adapter.write('foo', 'bar')
       (adapter.head.commit.tree / 'foo').should be_nil
       (adapter.head.commit.tree / 'db/things/foo').should_not be_nil
     end
 
     it 'should not clear other keys' do
       other_adapter = Adapter[:git].new(client, :branch => 'adapter-git')
-      other_adapter.set('foo', 'bar')
+      other_adapter.write('foo', 'bar')
 
-      adapter.set('foo', 'baz')
+      adapter.write('foo', 'baz')
       adapter.clear
 
-      other_adapter.get('foo').should == 'bar'
-      adapter.get('foo').should be_nil
+      other_adapter.read('foo').should == 'bar'
+      adapter.read('foo').should be_nil
     end
 
     it 'should not raise error on clear when branch does not exist' do

--- a/spec/git_spec.rb
+++ b/spec/git_spec.rb
@@ -23,6 +23,12 @@ describe "Git adapter" do
     client.get_head('foobar').should_not be_nil
   end
 
+  it 'overrides configured branch with :branch option' do
+    adapter.options[:branch] = 'foobar'
+    adapter.write('foo', 'bar', :branch => 'bazqux')
+    client.get_head('bazqux').should_not be_nil
+  end
+
   it 'should not raise error on clear when branch does not exist' do
     client.git.fs_delete("refs/heads/#{adapter.branch}")
     lambda { adapter.clear }.should_not raise_error
@@ -69,5 +75,29 @@ describe "Git adapter" do
       client.git.fs_delete("refs/heads/#{adapter.branch}")
       lambda { adapter.clear }.should_not raise_error
     end
+
+    it 'uses a default commit message if none specified' do
+      adapter.write('foo', 'bar')
+      adapter.head.commit.message.should == 'Updated foo'
+    end
+
+    it 'accepts a :message option for commit message' do
+      adapter.write('foo', 'bar', :message => 'Reticulating splines')
+      adapter.head.commit.message.should == 'Reticulating splines'
+    end
+
+    it 'accepts a commit :author option' do
+      author = Grit::Actor.new('Foo Bar', 'baz@qux.qx')
+      adapter.write('foo', 'bar', :author => author)
+      adapter.head.commit.author.name.should == author.name
+      adapter.head.commit.author.email.should == author.email
+    end
+
+    it 'accepts a option for :committed_date' do
+      commit_time = Time.now - 600
+      adapter.write('foo', 'bar', :committed_date => commit_time)
+      adapter.head.commit.committed_date.to_i.should == commit_time.to_i
+    end
+
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,5 @@ log_path  = root_path.join('log')
 log_path.mkpath
 
 require 'adapter/spec/an_adapter'
-require 'adapter/spec/json_adapter'
-require 'adapter/spec/types'
 
 require 'adapter-git'


### PR DESCRIPTION
- Adapter methods take options hash
- #set and #get aliases no longer available
# key_for is no longer implemented in Adapter. I re-added it as #seralize_key.
